### PR TITLE
Display error movie details page

### DIFF
--- a/src/App/App.js
+++ b/src/App/App.js
@@ -55,7 +55,7 @@ class App extends Component {
                 return (
                   <div className="movie-dets-and-form">
                     <MovieDetails {...movieToRender}/>
-                    <RateMovieForm />
+                    
                   </div>
                 )
               }}

--- a/src/MovieDetails/MovieDetails.css
+++ b/src/MovieDetails/MovieDetails.css
@@ -54,8 +54,8 @@
 
 .movie-overview {
   max-height: 40%;
-  width: 80%;
-  margin: 2% 0 2% 11%;
+  width: 85%;
+  margin: 1% 0 1% 8%;
   font-size: 1.4em;
   color: #EDE9EC;
   font-weight: bolder;

--- a/src/MovieDetails/MovieDetails.css
+++ b/src/MovieDetails/MovieDetails.css
@@ -60,3 +60,10 @@
   color: #EDE9EC;
   font-weight: bolder;
 }
+
+.error-message {
+  color: #EDE9EC;
+  font-weight: bolder;
+  margin: 2%;
+  font-size: 2.5em;
+}

--- a/src/MovieDetails/MovieDetails.css
+++ b/src/MovieDetails/MovieDetails.css
@@ -1,5 +1,5 @@
 .MovieDetails {
-
+  height: 100vh;
 }
 
 .movie-title-and-back-btn {
@@ -59,6 +59,10 @@
   font-size: 1.4em;
   color: #EDE9EC;
   font-weight: bolder;
+}
+
+.rate-form {
+  height: 20%;
 }
 
 .error-message {

--- a/src/MovieDetails/MovieDetails.js
+++ b/src/MovieDetails/MovieDetails.js
@@ -24,45 +24,52 @@ class MovieDetails extends Component {
     }
   };
 
-  // getGeneres = () => {
-    // const genres = this.state.movieDetails.genres;
-    // const seperatedGenres = genres.split(', ');
-    // return seperatedGenres;
-    // const splitGenres = JSON.stringify(this.state.movieDetails.genres);
-    // return splitGenres;
-  // }
-
   render() {
-    return (
-      <section className="MovieDetails">
-        <div className="movie-title-and-back-btn">
-          <h2 className="movie-title-dets-page">{this.props.title}</h2>
-          <button
-            className="back-to-all-movies-btn"
-            type="button"
-          >
-            View All Movies
-          </button>
-        </div>
-        <div className="movie-dets-img-holder">
-          <img
-            className="backdrop-img"
-            alt="movie poster"
-            src={this.props.backdrop_path}
-          ></img>
-          <div className="movie-dets">
-            <p className="dets">Release Date: {this.props.release_date}</p>
-            <p className="dets">Generes: {this.state.movieDetails.genres}</p>
-            <p className="dets">Budget: {this.state.movieDetails.budget}</p>
-            <p className="dets">Revenue: {this.state.movieDetails.revenue}</p>
-            <p className="dets">Runtime: {this.state.movieDetails.runtime}</p>
-            <p className="dets">Tagline: {this.state.movieDetails.tagline}</p>
-            <p className="dets">Average Rating: {this.state.movieDetails.average_rating}</p>
+    if (!this.state.error) {
+      return (
+        <section className="MovieDetails">
+          <div className="movie-title-and-back-btn">
+            <h2 className="movie-title-dets-page">{this.props.title}</h2>
+            <button className="back-to-all-movies-btn" type="button">
+              View All Movies
+            </button>
           </div>
-        </div>
-        <p className="movie-overview">Overview: {this.state.movieDetails.overview}</p>
-      </section>
-    );
+          <div className="movie-dets-img-holder">
+            <img
+              className="backdrop-img"
+              alt="movie poster"
+              src={this.props.backdrop_path}
+            ></img>
+            <div className="movie-dets">
+              <p className="dets">Release Date: {this.props.release_date}</p>
+              <p className="dets">Generes: {this.state.movieDetails.genres}</p>
+              <p className="dets">Budget: {this.state.movieDetails.budget}</p>
+              <p className="dets">Revenue: {this.state.movieDetails.revenue}</p>
+              <p className="dets">Runtime: {this.state.movieDetails.runtime}</p>
+              <p className="dets">Tagline: {this.state.movieDetails.tagline}</p>
+              <p className="dets">
+                Average Rating: {this.state.movieDetails.average_rating}
+              </p>
+            </div>
+          </div>
+          <p className="movie-overview">
+            Overview: {this.state.movieDetails.overview}
+          </p>
+        </section>
+      );
+    } else {
+      return (
+        <section className="MovieDetails">
+          <div className="movie-title-and-back-btn">
+            <h2 className="movie-title-dets-page">Opps!</h2>
+            <button className="back-to-all-movies-btn" type="button">
+              View All Movies
+            </button>
+          </div>
+          <div className="movie-dets-img-holder error-message">Sorry! There was an error loading your movie, please try again!</div>
+        </section>
+      );
+    }
   }
 }
 

--- a/src/MovieDetails/MovieDetails.js
+++ b/src/MovieDetails/MovieDetails.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import "./MovieDetails.css";
 import { getMovieDetails } from "../apiCalls";
+import RateMovieForm from "../RateMovieForm/RateMovieForm";
 
 class MovieDetails extends Component {
   constructor(props) {
@@ -55,6 +56,9 @@ class MovieDetails extends Component {
           <p className="movie-overview">
             Overview: {this.state.movieDetails.overview}
           </p>
+          <div className="rate-form">
+            {<RateMovieForm />}
+          </div>
         </section>
       );
     } else {

--- a/src/RateMovieForm/RateMovieForm.css
+++ b/src/RateMovieForm/RateMovieForm.css
@@ -1,6 +1,6 @@
 .RateMovieForm {
   width: 40%;
-  height: 25%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -28,7 +28,7 @@ export const postLogin = async (email, password) => {
 
 export const getMovieDetails = async (movieId) => {
   const response = await fetch (
-    `https://rancid-tomatillos.herokuapp.com/api/v/movies/${movieId}`
+    `${url}/movies/${movieId}`
   );
   const movieDetails = await response.json();
   console.log(movieDetails)

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -22,15 +22,13 @@ export const postLogin = async (email, password) => {
       })
     }
   )
-  // console.log(response)
   const message = await response.json();
-  // console.log('message', message)
   return message;
 }
 
 export const getMovieDetails = async (movieId) => {
   const response = await fetch (
-    `${url}/movies/${movieId}`
+    `https://rancid-tomatillos.herokuapp.com/api/v/movies/${movieId}`
   );
   const movieDetails = await response.json();
   console.log(movieDetails)


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Styling- MovieDetail page with and without errors.

### Detailed Description
- Added functionality so that if there is an error with the fetch grabbing a clicked movie, the MovieDetails page displays an apology saying there was an error and to please try again
- Moved the RateMovieForm to render inside of the MovieDetail page, only if there are no errors so that the user only sees it if everything is good to go.

### Why is this change required? What problem does it solve?

Adds a better user experience and so that the user cannot rate a movie until they see all of the selected movies details.

### Were there any challenges that arose while implementing this feature? If so, how were the addressed?

None.
